### PR TITLE
Fix undefined error in Cerebro console

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -8,7 +8,13 @@ const globToRegExp = require('glob-to-regexp');
 
 
 function parse (term) {
-  const match = term.match(/^pass\s+(.+)/)[1];
+  let match
+
+  try {
+    match = term.match(/^pass\s+(.+)/)[1]
+  } catch (error) {
+    return null
+  }
 
   if (match.split(' ')[1] && match.split(' ')[0].indexOf('gen') > -1){
     return {


### PR DESCRIPTION
Just noticed it was sometimes logging an error in the Cerebro console because of `term.match(/^pass\s+(.+)/)[1]` not always being valid, 37bc577 should fix that :+1: 